### PR TITLE
Big wave for pathmapping organization and fixes [DO NOT MERGE]

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,3 +1,5 @@
+ifeq ($(call my-dir),$(call project-path-for,qcom-audio))
+
 ifneq ($(filter mpq8092 msm8960 msm8226 msm8x26 msm8610 msm8974 msm8x74 apq8084,$(TARGET_BOARD_PLATFORM)),)
 
 MY_LOCAL_PATH := $(call my-dir)
@@ -16,6 +18,8 @@ include $(MY_LOCAL_PATH)/policy_hal/Android.mk
 include $(MY_LOCAL_PATH)/visualizer/Android.mk
 include $(MY_LOCAL_PATH)/audiod/Android.mk
 include $(MY_LOCAL_PATH)/post_proc/Android.mk
+endif
+
 endif
 
 endif

--- a/hal/audio_extn/audio_extn.c
+++ b/hal/audio_extn/audio_extn.c
@@ -484,9 +484,11 @@ err:
 void audio_extn_perf_lock_acquire(int *handle, int duration,
                                  int *perf_lock_opts, int size)
 {
-
-    if (!perf_lock_opts || !size || !perf_lock_acq || !handle)
-        return -EINVAL;
+    if (!perf_lock_opts || !size || !perf_lock_acq || !handle) {
+        ALOGE("%s: Incorrect params, Failed to acquire perf lock, err ",
+              __func__);
+        return;
+    }
     /*
      * Acquire performance lock for 1 sec during device path bringup.
      * Lock will be released either after 1 sec or when perf_lock_release


### PR DESCRIPTION
I'm cleaning my work into very few changes from my repos with the basic stuff I've tested so far. This specific pull request deals with a fix for the MSM8994 backport of audio features introduced recently and adds pathmapping support to be used on HALs/manifest organization. Do not merge this patch without its counterparts in build, frameworks native and manifest as it will potentially break the builds. The other patches can take more time to clean as my time is limited this week but they'll come.
