### PR TITLE
hal: add debugging log for acquire perf lock function

### DIFF
--- a/hal/audio_extn/audio_extn.c
+++ b/hal/audio_extn/audio_extn.c
@@ -484,9 +484,11 @@ err:
 void audio_extn_perf_lock_acquire(int *handle, int duration,
                                  int *perf_lock_opts, int size)
 {
-
-    if (!perf_lock_opts || !size || !perf_lock_acq || !handle)
-        return -EINVAL;
+    if (!perf_lock_opts || !size || !perf_lock_acq || !handle) {
+        ALOGE("%s: Incorrect params, failed to acquire perf lock",
+              __func__);
+        return;
+    }
     /*
      * Acquire performance lock for 1 sec during device path bringup.
      * Lock will be released either after 1 sec or when perf_lock_release


### PR DESCRIPTION
Useful to debug the parameters passed to perf lock.

Signed-off-by: Ícaro Hoff icarohoff@gmail.com
